### PR TITLE
Add typescript definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "2.0.0",
   "author": "Andreas Madsen <amwebdk@gmail.com>",
   "main": "./distributions.js",
+  "types": "types.d.ts",
   "scripts": {
     "test": "tap test/simple/*"
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,15 @@
+interface Distribution {
+  pdf: (x: number) => number;
+  cdf: (x: number) => number;
+  inv: (p: number) => number;
+  mean: () => number;
+  median: () => number;
+  variance: () => number;
+}
+
+declare module 'distributions' {
+  export function Normal(mean?: number, sd?: number): Distribution;
+  export function Studentt(df: number): Distribution;
+  export function Uniform(a?: number, b?: number): Distribution;
+  export function Binomial(properbility: number, size: number): Distribution;
+}


### PR DESCRIPTION
This PR does not change any functionality, but it declares a typescript module for the package.
With the next publish, typescript consumers will have a friction-less experience because they will not have to add types definitions of your package in their project.